### PR TITLE
add list-after for CME ControlPanel and fix small bugs

### DIFF
--- a/build.json
+++ b/build.json
@@ -104,7 +104,8 @@
       "fields": {
         "title": "$:/plugins/Gk0Wk/TW5-CodeMirror-Enhanced/ControlPanel",
         "tags": "$:/tags/ControlPanel/SettingsTab $:/tags/MoreSideBar",
-        "caption": "CME"
+        "caption": "CME",
+        "list-after": "$:/core/ui/ControlPanel/Settings/TiddlyWiki"
       }
     },
     {

--- a/src/i18n/en-GB.json
+++ b/src/i18n/en-GB.json
@@ -1,6 +1,6 @@
 {
   "readme": [
-    "View more on [[GitHub Repo|https://github.com/Gk0Wk/TW5-CodeMirror-Enhanced]].",
+    "View more on [[~GitHub Repo|https://github.com/Gk0Wk/TW5-CodeMirror-Enhanced]].",
     "",
     "CodeMirror editor for TiddlyWiki provides a flexible and rich extension framework (including highlighting, completion, preview and other features), anyone can use this framework to write extension plug-ins for the editor! Currently based on this framework to achieve the following features.",
     "",
@@ -79,9 +79,11 @@
       "preview": [
         "!! You can use triple backticks <code>&#96;&#96;&#96;</code> to mark code blocks",
         "",
+        "",
         "```",
         "This will be monospaced",
         "```",
+        "",
         "",
         "To be interpreted correctly, the three backticks need to be at the start of the line and immediately followed by a line-break.",
         "",

--- a/src/i18n/zh-Hans.json
+++ b/src/i18n/zh-Hans.json
@@ -1,6 +1,6 @@
 {
   "readme": [
-    "如想了解更多，请关注我们的[[GitHub Repo|https://github.com/Gk0Wk/TW5-CodeMirror-Enhanced]]。",
+    "如想了解更多，请关注我们的[[~GitHub Repo|https://github.com/Gk0Wk/TW5-CodeMirror-Enhanced]]。",
     "",
     "为TiddlyWiki的CodeMirror编辑器提供一个灵活而丰富的扩展框架(包括高亮、补全、预览等功能)，任何人都可以使用此框架为编辑器编写扩展插件！目前基于此框架实现的功能有：",
     "",
@@ -79,9 +79,11 @@
       "preview": [
         "!! 你可以使用三个反斜线<code>&#96;&#96;&#96;</code>来标记代码块",
         "",
+        "",
         "```",
         "这将是以等宽字体显示的。",
         "```",
+        "",
         "",
         "为了正确显示，这三个反斜线需要在行的开头，并紧跟一个换行。",
         "",


### PR DESCRIPTION
增加：

- 把CME的设置中心放到TiddlyWiki后面

![image](https://user-images.githubusercontent.com/42492105/140886133-711e4d6d-b919-4a08-a172-bcdf4bcf2d2b.png)

修复：

- readme里`[[GitHub xxxxx|http://xxx]]`链接点击时可能会点到GitHub链接
- 代码块snippet忘了换两行
